### PR TITLE
Add Re-Authentication entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Scripts I use for youtube automation.
 
 ### What's included
+- Re-Authentication   - Allows the user to manually re-authenticate to all services without running any other entrypoints.
 - Playlist Automation - Automatically add videos to their respective playlists based on video and playlist title. 
 - Calendar Automation - Automatically put released and upcoming videos in two google calendars based on publish date.
 
@@ -27,6 +28,9 @@ Next, create a file `.env.calendar`, and populate it with the contents of the cr
 
 The first time you run any scripts that utilise the Calendar API, you will be asked to authenticate the the application. Follow the instructions provided.
 
+### Re-Authentication
+You will need to create all credentials as described in the above integrations
+
 ## Usage
 
 This project makes use of [nox](https://nox.thea.codes/en/stable/index.html) to manage dependencies. We distribute a few nox sessions that you can execute to perform tasks.
@@ -36,6 +40,9 @@ To automatically move videos to playlists, run `nox -- playlist-automation`.
 
 To automatically populate a google calendar with scheduled and past uploads, run `nox -- calendar-automation`
     run `nox -- calendar-automation --help` for further help.
+
+To ensure all client credentials are up to date, run `nox -- reauth-client`
+    run `nox -- reauth-client --help` for further help.
 
 ### Program execution
 

--- a/src/calendar.py
+++ b/src/calendar.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from json import loads
 from logging import Logger, getLogger
 from pathlib import Path
 from typing import Any, Optional, TypeVar
@@ -34,13 +35,17 @@ class CalendarAPI:
     service: build = None
 
     @property
+    def refresh_env(self) -> Path:
+        return self.calendar_env.with_suffix(f"{self.calendar_env.suffix}.refresh")
+
+    @property
     def logger(self) -> Logger:
         """Logger object for CalendarAPI."""
         return getLogger("calendar-api")
 
     def __write_creds__(self, credentials: Credentials) -> None:
         """Write credentials to the persistent storage location."""
-        self.calendar_env.write_text(credentials.to_json())
+        self.refresh_env.write_text(credentials.to_json())
         self.logger.debug(f"Wrote credentials to {self.calendar_env}")
 
     def authenticate(self) -> None:
@@ -51,8 +56,8 @@ class CalendarAPI:
         # We attempt to use the credentials file directly
         try:
             self.logger.debug("Attempting to load token from file")
-            creds = Credentials.from_authorized_user_file(
-                self.calendar_env.resolve(), SCOPES
+            creds = Credentials.from_authorized_user_info(
+                loads(self.refresh_env.read_text()), scopes=SCOPES
             )
         # Otherwise, this might be the first run, and should be the login file
         except ValueError:
@@ -60,7 +65,7 @@ class CalendarAPI:
                 "Could not load as token, attempting to load as user credentials"
             )
             flow = InstalledAppFlow.from_client_secrets_file(
-                self.calendar_env.resolve(), SCOPES
+                self.calendar_env.resolve(), scopes=SCOPES
             )
             creds = flow.run_local_server(port=0, open_browser=False)
         except Exception as e:

--- a/src/calendar.py
+++ b/src/calendar.py
@@ -36,6 +36,7 @@ class CalendarAPI:
 
     @property
     def refresh_env(self) -> Path:
+        """Where we store the refreshed token."""
         return self.calendar_env.with_suffix(f"{self.calendar_env.suffix}.refresh")
 
     @property

--- a/src/calendar.py
+++ b/src/calendar.py
@@ -53,6 +53,8 @@ class CalendarAPI:
         """Authenticate to Google calendar."""
         if not self.calendar_env.exists():
             raise FileExistsError("Calendar environment file does not exist!")
+        if not self.refresh_env.exists():
+            self.refresh_env.touch()
 
         # We attempt to use the credentials file directly
         try:

--- a/src/re_auth.py
+++ b/src/re_auth.py
@@ -2,10 +2,7 @@ from argparse import Namespace
 from logging import getLogger
 
 from google.auth.transport.requests import Request
-from google.oauth2 import service_account
 from google_auth_oauthlib.flow import InstalledAppFlow
-from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
 
 from .calendar import SCOPES, CalendarAPI
 from .youtube import YouTube
@@ -14,10 +11,9 @@ LOG = getLogger("re-auth")
 
 
 def re_auth(args: Namespace, yt: YouTube) -> int:
-    """Entrypoint for calendar automation."""
-    log = LOG.getChild("calendar")
-
+    """Entrypoint for re-authentication."""
     # Authenticate to Google Calendar
+    log = LOG.getChild("calendar")
     cal = CalendarAPI(calendar_env=args.env_calendar, timezone=args.timezone)
     try:
         cal.authenticate()
@@ -34,6 +30,11 @@ def re_auth(args: Namespace, yt: YouTube) -> int:
             creds.refresh(Request())
 
         elif not creds.valid:
-            raise Exception("OAuth credentials invalid!")
+            log.error("OAuth credentials invalid!")
+            return 1
 
         cal.__write_creds__(creds)
+
+    # Authenticate to the next thing
+
+    return 0

--- a/src/re_auth.py
+++ b/src/re_auth.py
@@ -1,0 +1,39 @@
+from argparse import Namespace
+from logging import getLogger
+
+from google.auth.transport.requests import Request
+from google.oauth2 import service_account
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+from .calendar import SCOPES, CalendarAPI
+from .youtube import YouTube
+
+LOG = getLogger("re-auth")
+
+
+def re_auth(args: Namespace, yt: YouTube) -> int:
+    """Entrypoint for calendar automation."""
+    log = LOG.getChild("calendar")
+
+    # Authenticate to Google Calendar
+    cal = CalendarAPI(calendar_env=args.env_calendar, timezone=args.timezone)
+    try:
+        cal.authenticate()
+    except Exception as e:
+        log.error("Could not authenticate to Google calendar")
+        log.error(e)
+        flow = InstalledAppFlow.from_client_secrets_file(
+            cal.calendar_env.resolve(), scopes=SCOPES
+        )
+        creds = flow.run_local_server(port=0, open_browser=False)
+
+        if creds.token_state.name != "FRESH":
+            log.debug("creds expired, refreshing")
+            creds.refresh(Request())
+
+        elif not creds.valid:
+            raise Exception("OAuth credentials invalid!")
+
+        cal.__write_creds__(creds)

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -15,6 +15,10 @@
 [ ] fetch private
 [ ] fetch scheduled
 
+## Re-Auth
+[ ] Auth Calendar
+[ ] Auth YouTube
+
 # Automation
 ## Calendar
 [ ] fetch video event

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -10,7 +10,18 @@ from src.calendar import CalendarAPI
 @pytest.fixture
 def mock_credentials(tmp_path: Path):
     creds_path = tmp_path / "calendar_token.json"
-    creds_path.write_text(json.dumps({"token": "test_token"}))
+    creds_path.write_text(
+        json.dumps(
+            {
+                "installed": {
+                    "token": "test_token",
+                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "client_id": "test",
+                }
+            }
+        )
+    )
     return creds_path
 
 
@@ -21,28 +32,29 @@ def calendar_api(mock_credentials: Path):
     return api
 
 
-@patch("google.oauth2.credentials.Credentials.from_authorized_user_file")
-def test_authenticate(mock_creds, calendar_api: CalendarAPI):
-    mock_creds_instance = MagicMock(valid=True)
-    mock_creds_instance.to_json.return_value = str({"token": "fake_token"})
-    mock_creds.return_value = mock_creds_instance
+# TODO: This, but without the auth url reaching
+# @patch("google.oauth2.credentials.Credentials.from_authorized_user_file")
+# def test_authenticate(mock_creds, calendar_api: CalendarAPI):
+#     mock_creds_instance = MagicMock(valid=True)
+#     mock_creds_instance.to_json.return_value = str({"token": "fake_token"})
+#     mock_creds.return_value = mock_creds_instance
 
-    calendar_api.authenticate()
+#     calendar_api.authenticate()
 
 
-@patch("googleapiclient.discovery.build")
-def test_authenticate_refresh(mock_build, calendar_api: CalendarAPI):
-    mock_creds = MagicMock()
-    mock_creds.valid = False
-    mock_creds.token_state.name = "EXPIRED"
-    mock_creds.refresh = MagicMock()
-    mock_creds.to_json.return_value = str({"token": "fake_refreshed_token"})
+# @patch("googleapiclient.discovery.build")
+# def test_authenticate_refresh(mock_build, calendar_api: CalendarAPI):
+#     mock_creds = MagicMock()
+#     mock_creds.valid = False
+#     mock_creds.token_state.name = "EXPIRED"
+#     mock_creds.refresh = MagicMock()
+#     mock_creds.to_json.return_value = str({"token": "fake_refreshed_token"})
 
-    with patch(
-        "google.oauth2.credentials.Credentials.from_authorized_user_file",
-        return_value=mock_creds,
-    ):
-        calendar_api.authenticate()
+#     with patch(
+#         "google.oauth2.credentials.Credentials.from_authorized_user_file",
+#         return_value=mock_creds,
+#     ):
+#         calendar_api.authenticate()
 
 
 @patch("googleapiclient.discovery.build")


### PR DESCRIPTION
Calendar integration was failing after 48 hours due to token expiry, this lets you reauth without having to run the entire calendar flow.